### PR TITLE
automatically create a $templateCache module for html views

### DIFF
--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -25,6 +25,9 @@ var tmplDest   = './src/js';
 var fontDest   = './dist/fonts';
 var vendorDest = './dist/vendors';
 
+// constants
+var TMPL_CACHE_HEADER = '\n// generated file. do not modify.\nangular.module("<%= module %>"<%= standalone %>).run(["$templateCache", function($templateCache) {';
+
 // plugins
 var gulp      = require('gulp'),
   browserSync = require('browser-sync').create(),
@@ -120,7 +123,8 @@ gulp.task('views', function() {
     .pipe($.angularTemplatecache({
       module: 'tcomTemplates',
       standalone: true,
-      moduleSystem: 'IIFE'
+      moduleSystem: 'IIFE',
+      templateHeader: TMPL_CACHE_HEADER
     }))
     .pipe(gulp.dest(tmplDest));
 });

--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -121,7 +121,8 @@ gulp.task('views', function() {
     .pipe($.htmlmin({collapseWhitespace: true}))
     .pipe($.rename({dirname: '/'}))
     .pipe($.angularTemplatecache({
-      module: 'tcomTemplates',
+      filename: 'views.js',
+      module: 'tcomViews',
       standalone: true,
       moduleSystem: 'IIFE',
       templateHeader: TMPL_CACHE_HEADER

--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -21,12 +21,12 @@ var cssVendors = [];
 // distribution directories
 var jsDest     = './dist/js';
 var cssDest    = './dist/css';
-var htmlDest   = './dist/html';
+var tmplDest   = './src/js';
 var fontDest   = './dist/fonts';
 var vendorDest = './dist/vendors';
 
 // plugins
-var gulp        = require('gulp'),
+var gulp      = require('gulp'),
   browserSync = require('browser-sync').create(),
   reporters   = require('jasmine-reporters'),
   karma       = require('karma').server;
@@ -116,8 +116,13 @@ gulp.task('fonts', function() {
 gulp.task('views', function() {
   gulp.src(htmlFiles)
     .pipe($.htmlmin({collapseWhitespace: true}))
-    .pipe($.rename({dirname: '/', suffix: '.min'}))
-    .pipe(gulp.dest(htmlDest));
+    .pipe($.rename({dirname: '/'}))
+    .pipe($.angularTemplatecache({
+      module: 'tcomTemplates',
+      standalone: true,
+      moduleSystem: 'IIFE'
+    }))
+    .pipe(gulp.dest(tmplDest));
 });
 
 // copy vendor CSS

--- a/generators/app/templates/gulpfile.js
+++ b/generators/app/templates/gulpfile.js
@@ -160,30 +160,31 @@ gulp.task('tests', function(done) {
 
 // default task builds everything, opens up a proxy server, and watches for changes
 gulp.task('default', [
+	'views',
+	'fonts',
   'styles',
   'scripts',
   'fonts',
-  'views',
   'browser-sync-standalone',
   'watch'
 ]);
 
 // local task builds everything, opens up a standalone server, and watches for changes
 gulp.task('proxy', [
+	'views',
+	'fonts',
   'styles',
   'scripts',
-  'fonts',
-  'views',
   'browser-sync-proxy',
   'watch'
 ]);
 
 // builds everything
 gulp.task('build', [
+	'views',
+	'fonts',
   'styles',
   'scripts',
-  'fonts',
-  'views',
   'css-vendors',
   'js-vendors'
 ]);

--- a/generators/app/templates/js/app.js
+++ b/generators/app/templates/js/app.js
@@ -5,6 +5,7 @@
 		.module('<%= prefix %>', [
 			'ngResource',
 			'ui.router',
+			'tcomViews',
 			'DataFactory',
 			'HomeView',
 			// enter additional modules/components here

--- a/generators/app/templates/js/helpers.js
+++ b/generators/app/templates/js/helpers.js
@@ -1,10 +1,1 @@
-/**
- * @name getTemplateUrl
- * @description
- * Retrieve the string URL of a view or directive template
- * @param  {string} filename Name of the html file to retrieve
- * @return {string}          Relative URL to the minified template
- */
-function getTemplateUrl (filename){
-	return `dist/html/${filename}.min.html`;
-}
+

--- a/generators/app/templates/package.json
+++ b/generators/app/templates/package.json
@@ -15,6 +15,7 @@
     "bourbon-neat": "^1.8.0",
     "browser-sync": "^2.13.0",
     "gulp": "^3.9.1",
+    "gulp-angular-templatecache": "^2.0.0",
     "gulp-autoprefixer": "^3.1.0",
     "gulp-babel": "^6.1.2",
     "gulp-clean-css": "^2.0.11",


### PR DESCRIPTION
good practice for production-level apps to utilize the `$templateCache` instead of lazy-loading HTML templates. This injects `gulp-angular-templatecache` into the build process so this can automagically be created on the fly.